### PR TITLE
Fix empty POST request

### DIFF
--- a/visa-cloud/src/main/java/eu/ill/visa/cloud/http/clients/OkHttpClientAdapter.java
+++ b/visa-cloud/src/main/java/eu/ill/visa/cloud/http/clients/OkHttpClientAdapter.java
@@ -99,7 +99,7 @@ public class OkHttpClientAdapter implements HttpClient {
     public HttpResponse sendRequest(final String url,
                                     final HttpMethod method,
                                     final Map<String, String> headers) throws CloudException {
-        return sendRequest(url, method, headers, null);
+        return sendRequest(url, method, headers, "{}");
     }
 
     @Override

--- a/visa-cloud/src/main/java/eu/ill/visa/cloud/http/clients/OkHttpClientAdapter.java
+++ b/visa-cloud/src/main/java/eu/ill/visa/cloud/http/clients/OkHttpClientAdapter.java
@@ -5,6 +5,7 @@ import eu.ill.visa.cloud.http.HttpClient;
 import eu.ill.visa.cloud.http.HttpMethod;
 import eu.ill.visa.cloud.http.HttpResponse;
 import okhttp3.*;
+import okhttp3.internal.Util;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class OkHttpClientAdapter implements HttpClient {
     }
 
     private HttpResponse doPost(final String url, final Headers headers, final String data) throws CloudException {
-        final RequestBody body = RequestBody.create(JSON_CONTENT_TYPE, data);
+        final RequestBody body = data == null ? Util.EMPTY_REQUEST : RequestBody.create(JSON_CONTENT_TYPE, data);
         final Request request = new Request.Builder()
             .url(url)
             .headers(headers)
@@ -99,7 +100,7 @@ public class OkHttpClientAdapter implements HttpClient {
     public HttpResponse sendRequest(final String url,
                                     final HttpMethod method,
                                     final Map<String, String> headers) throws CloudException {
-        return sendRequest(url, method, headers, "{}");
+        return sendRequest(url, method, headers, null);
     }
 
     @Override


### PR DESCRIPTION
The RequestBody.create does not accept null value.
As consequence `doPost(url, headers)` method always raises an Exception.

Use Util.EMPTY_REQUEST, instead when `data` is null.