### PR TITLE
Feature/instance metadata experiments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,41 @@
+stages:
+  - build
+
+variables:
+  IMAGE: ${CI_REGISTRY_IMAGE}
+
+build:
+  stage: build
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [""]
+  script:
+    - mkdir -p /kaniko/.docker
+    - echo "{\"auths\":{\"${CI_REGISTRY}\":{\"username\":\"${CI_REGISTRY_USER}\",\"password\":\"${CI_REGISTRY_PASSWORD}\"}}}" > /kaniko/.docker/config.json
+
+    # Git Branch/Tag to Docker Image Tag Mapping
+    #   * Default Branch: main -> latest
+    #   * Branch: feature/my-feature -> branch-feature-my-feature
+    #   * Tag: v1.0.0/beta2 -> v1.0.0-beta2
+    - |
+      set -- "--destination" "${IMAGE}:${CI_COMMIT_SHORT_SHA}"
+
+      if [ "${CI_COMMIT_REF_NAME}" = "${CI_DEFAULT_BRANCH}" ]; then
+        set -- "$@" "--destination" "${IMAGE}:latest"
+      else
+        CI_COMMIT_REF="${CI_COMMIT_TAG:-branch-$CI_COMMIT_REF_NAME}"
+        NO_SLASH=$(echo "${CI_COMMIT_REF}" | tr -s / -)
+        SANITIZED=$(echo "${NO_SLASH}" | tr -cd '[:alnum:]_.-')
+        set -- "$@" "--destination" "${IMAGE}:${SANITIZED}"
+      fi
+
+      for var in http_proxy https_proxy no_proxy; do
+        eval "value=\$$var"
+        if [ -n "$value" ]; then
+          set -- "$@" "--build-arg" "${var}=${value}"
+        fi
+      done
+
+      /kaniko/executor "$@" \
+        --context "${CI_PROJECT_DIR}" \
+        --dockerfile "${CI_PROJECT_DIR}/Dockerfile"

--- a/visa-business/src/main/java/eu/ill/visa/business/concurrent/actions/CreateInstanceAction.java
+++ b/visa-business/src/main/java/eu/ill/visa/business/concurrent/actions/CreateInstanceAction.java
@@ -50,6 +50,10 @@ public class CreateInstanceAction extends InstanceAction {
 
             List<String> proposals = instance.getExperiments().stream().map(experiment -> experiment.getProposal().getIdentifier()).collect(Collectors.toUnmodifiableList());
 
+            List<String> experiments = instance.getExperiments().stream()
+                .map(experiment -> String.format("%s:%s", experiment.getInstrument().getName(), experiment.getProposal().getIdentifier()))
+                .collect(Collectors.toUnmodifiableList());
+
             final CloudInstanceMetadata metadata = new CloudInstanceMetadata();
 
             instance.getAttributes().forEach(attribute -> metadata.put(attribute.getName(), attribute.getValue()));
@@ -57,6 +61,7 @@ public class CreateInstanceAction extends InstanceAction {
             metadata.put("owner", instance.getUsername());
             metadata.put("instruments", String.join(",", instrumentNames));
             metadata.put("proposals", String.join(",", proposals));
+            metadata.put("experiments", String.join(",", experiments));
 
             String pamPublicKey = this.getSignatureService().readPublicKey();
             if (pamPublicKey != null) {


### PR DESCRIPTION
Hi,

In our institute, the path to the user data depends on the <Instrument, Proposal> pair bound to the experiment. Therefore, we need additional metadata to be able to provide access to it. 

This pull request adds a new field to the instance metadata, `experiments`: comma-separated pairs of `<instrument>:<experiment>`. Here's an example:
```diff
 "meta": {
+  "experiments": "apollon:70097250,dionysos:89264518,apollon:92456339",
   "home": "/home/<username>",
   "id": "<id>",
   "instruments": "dionysos,apollon",
   "owner": "<username>",
   "pamPublicKey": "-----BEGIN PUBLIC KEY-----\n...",
   "proposals": "70097250,89264518,92456339",
   "uid": "<uid>"
 }
```