### PR TITLE
Avoid json serialization of instrument scientists

### DIFF
--- a/visa-core/src/main/java/eu/ill/visa/core/entity/Instrument.java
+++ b/visa-core/src/main/java/eu/ill/visa/core/entity/Instrument.java
@@ -1,5 +1,6 @@
 package eu.ill.visa.core.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -64,6 +65,7 @@ public class Instrument {
     @Column(name = "name", length = 250, nullable = false)
     private String name;
 
+    @JsonIgnore
     @ManyToMany()
     @JoinTable(
         name = "instrument_scientist",


### PR DESCRIPTION
Remove instrument scientists from json conversion to avoid any persistent bag errors on serialization.

Closes #5 